### PR TITLE
Fix/get iface name as su

### DIFF
--- a/apk/utils/net_utils.py
+++ b/apk/utils/net_utils.py
@@ -63,7 +63,7 @@ def get_net_iface_name() -> str:
         result = subprocess.run(['su', '-c', 'getprop wifi.interface'], capture_output=True, text=True)
         Logger.info(f"{DEADNET_PREF}: get_net_iface_name cmd getprop result - {result}")
         iface_name = result.stdout.strip()
-        if False: #iface_name:
+        if iface_name:
             return iface_name
         else:  # fallback: parse /proc/net/wireless
             Logger.error(f"{DEADNET_PREF}: getprop cmd failed, trying fallback...")
@@ -72,7 +72,6 @@ def get_net_iface_name() -> str:
                 Logger.info(f"{DEADNET_PREF}: get_net_iface_name cmd 'cat /proc/net/wireless' result - {fallback_result}")
                 lines = fallback_result.stdout.splitlines()
                 for line in lines[2:]:  # skip headers (first 2 lines)
-                    break
                     if line.strip():
                         parts = line.split()
                         if len(parts) >= 3:

--- a/apk/utils/net_utils.py
+++ b/apk/utils/net_utils.py
@@ -71,7 +71,8 @@ def get_net_iface_name() -> str:
                 fallback_result = subprocess.run(['su', '-c', 'cat /proc/net/wireless'], capture_output=True, text=True)
                 Logger.info(f"{DEADNET_PREF}: get_net_iface_name cmd 'cat /proc/net/wireless' result - {fallback_result}")
                 lines = fallback_result.stdout.splitlines()
-                for line in lines[2:]: # skip headers (first 2 lines)
+                for line in lines[2:]:  # skip headers (first 2 lines)
+                    break
                     if line.strip():
                         parts = line.split()
                         if len(parts) >= 3:
@@ -90,7 +91,7 @@ def get_net_iface_name() -> str:
 
     except Exception as e:
         Logger.error(f"{DEADNET_PREF}: get_net_iface_name error {e} - {traceback.format_exc()}")
-    Logger.info(f"{DEADNET_PREF}: get_net_iface_name failed, returning default {IFACE_DEFAULT_NAME}")
+    Logger.info(f"{DEADNET_PREF}: get_net_iface_name failed, returning default name '{IFACE_DEFAULT_NAME}'")
     return IFACE_DEFAULT_NAME
 
 


### PR DESCRIPTION
## Bugfixes
* APK - call `getprop` as su and narrow down to 1 property in order to reduce the output
* APK - `stderr` sometimes would not be captured

## Features
* APK - Get interface name fallback 1 - fetch from `/proc/net/wireless`
* APK - Get interface name fallback 2 - use default value `wlan0`